### PR TITLE
feat: add OpenAI-powered python sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ BMAD™'s natural language framework works in ANY domain. Expansion packs provid
 
 ## Documentation & Resources
 
+### SDKs & Integrations
+
+- 🐍 **[Python SDK (Simulator)](bmad_python_sdk/README.md)** – Reference implementation that simulates the BMAD workflow without calling an external provider. Originally designed for the Google Agents ADK.
+- 🤖 **[Python SDK for OpenAI Agents](bmad_openai_sdk/README.md)** – Drop-in alternative that drives BMAD agents through the OpenAI Agents SDK/Responses API.
+
 ### Essential Guides
 
 - 📖 **[User Guide](docs/user-guide.md)** - Complete walkthrough from project inception to completion

--- a/bmad_openai_sdk/README.md
+++ b/bmad_openai_sdk/README.md
@@ -1,0 +1,52 @@
+# BMAD OpenAI Python SDK
+
+This directory contains an alternative Python SDK for BMAD (Breakthrough Method of Agile AI-Driven Development) that targets the **OpenAI Agents SDK**. It mirrors the structure of the original Google Agents ADK prototype while providing real integration points for the OpenAI Responses/Agents runtime.
+
+## Components
+
+- `agents.py` – Implements `OpenAIAgent`, a concrete agent that reads persona definitions from `bmad-core/agents` and executes work through the OpenAI Responses API.
+- `workflow.py` – Contains `OpenAIWorkflow`, a runner that orchestrates a workflow definition (for example `bmad-core/workflows/greenfield-fullstack.yaml`) by invoking `OpenAIAgent` instances. It returns both a log of execution events and the generated artifacts/context.
+- `prompts.py` – Utility helpers for rendering BMAD YAML templates into rich prompts that can be fed to the OpenAI APIs.
+- `__init__.py` – Convenience exports so the SDK can be imported as a module.
+
+## Installation
+
+The SDK depends on the official `openai` Python package. Install the library and export an API key before running workflows:
+
+```bash
+pip install openai pyyaml
+export OPENAI_API_KEY="sk-..."
+```
+
+Alternatively, pass a configured `OpenAI` client object when instantiating `OpenAIAgent` or `OpenAIWorkflow`.
+
+## Usage
+
+```python
+from bmad_openai_sdk import OpenAIWorkflow
+
+workflow = OpenAIWorkflow(
+    workflow_definition_path="bmad-core/workflows/greenfield-fullstack.yaml",
+    default_model="gpt-4.1-mini",
+)
+
+result = workflow.run(initial_context={"project_name": "Lunar CRM"}, dry_run=True)
+
+print("\n".join(result.log))
+```
+
+Switch `dry_run` to `False` (the default) to stream the tasks to the OpenAI APIs. Use the `agent_overrides` argument to tailor models or runtime parameters for specific agents.
+
+For prompt-centric workflows you can reuse the shared template helper:
+
+```python
+from bmad_openai_sdk import generate_prompt_from_template
+
+prompt = generate_prompt_from_template(
+    "bmad-core/templates/prd-tmpl.yaml",
+    {"project_name": "Lunar CRM", "user_type": "Admin"}
+)
+print(prompt)
+```
+
+This SDK serves as a starting point for executing BMAD playbooks with OpenAI-hosted agents while keeping compatibility with the BMAD Core assets.

--- a/bmad_openai_sdk/__init__.py
+++ b/bmad_openai_sdk/__init__.py
@@ -1,0 +1,12 @@
+"""OpenAI-powered BMAD SDK."""
+
+from .agents import OpenAIAgent
+from .workflow import OpenAIWorkflow, WorkflowRunResult
+from .prompts import generate_prompt_from_template
+
+__all__ = [
+    "OpenAIAgent",
+    "OpenAIWorkflow",
+    "WorkflowRunResult",
+    "generate_prompt_from_template",
+]

--- a/bmad_openai_sdk/agents.py
+++ b/bmad_openai_sdk/agents.py
@@ -1,0 +1,219 @@
+"""Agent abstractions powered by the OpenAI Agents SDK."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterable, List, Optional
+
+from bmad_python_sdk.agents import Agent as BaseAgent
+
+try:  # pragma: no cover - optional dependency for runtime use
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - handled at runtime
+    OpenAI = None  # type: ignore
+
+
+class OpenAIAgent(BaseAgent):
+    """Concrete BMAD agent that talks to the OpenAI Agents SDK."""
+
+    def __init__(
+        self,
+        agent_id: str,
+        agent_definition_path: str,
+        *,
+        client: Optional["OpenAI"] = None,
+        model: str = "gpt-4.1-mini",
+        response_kwargs: Optional[Dict[str, Any]] = None,
+        client_options: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(agent_id, agent_definition_path)
+        self.client: Optional["OpenAI"] = client
+        self.model = model
+        self.response_kwargs = response_kwargs or {}
+        self._client_options = client_options or {}
+
+    # ---------------------------------------------------------------------
+    # Prompt helpers
+    # ---------------------------------------------------------------------
+    def _format_persona(self) -> str:
+        if not self.persona:
+            return ""
+
+        lines: List[str] = []
+        for key, value in self.persona.items():
+            human_key = key.replace("_", " ").strip().capitalize()
+            if isinstance(value, Iterable) and not isinstance(value, (str, bytes, dict)):
+                lines.append(f"{human_key}:")
+                for item in value:
+                    lines.append(f"- {item}")
+            elif isinstance(value, dict):
+                lines.append(f"{human_key}:")
+                for sub_key, sub_value in value.items():
+                    lines.append(f"  - {sub_key}: {sub_value}")
+            else:
+                lines.append(f"{human_key}: {value}")
+        return "\n".join(lines)
+
+    def _format_commands(self) -> str:
+        if not self.commands:
+            return "No explicit command shortcuts are defined for this agent."
+
+        lines = ["Available Commands:"]
+        for entry in self.commands:
+            if isinstance(entry, dict):
+                for command, description in entry.items():
+                    lines.append(f"- {command}: {description}")
+            else:
+                lines.append(f"- {entry}")
+        return "\n".join(lines)
+
+    def _format_dependencies(self) -> str:
+        if not self.dependencies:
+            return "No external dependencies declared."
+
+        lines = ["Referenced Dependencies:"]
+        for dep_type, items in self.dependencies.items():
+            lines.append(f"- {dep_type}:")
+            for item in items:
+                lines.append(f"  - {item}")
+        return "\n".join(lines)
+
+    def _format_context(self, context: Dict[str, Any]) -> str:
+        if not context:
+            return "None provided."
+
+        lines = []
+        for key, value in context.items():
+            lines.append(f"- {key}: {value}")
+        return "\n".join(lines)
+
+    def build_system_prompt(self, context: Optional[Dict[str, Any]] = None) -> str:
+        """Assemble the system instructions sent to the OpenAI model."""
+
+        context = context or {}
+        agent_title = self.agent_info.get("title") or self.agent_id
+        agent_name = self.agent_info.get("name", "")
+        base = [
+            f"You are {agent_title} ({self.agent_id}).",
+            "Adopt the persona and operating constraints defined for the BMAD workflow.",
+        ]
+        if agent_name:
+            base.insert(0, f"Agent name: {agent_name}")
+
+        persona_block = self._format_persona()
+        if persona_block:
+            base.append("\nPersona:")
+            base.append(persona_block)
+
+        dependencies_block = self._format_dependencies()
+        if dependencies_block:
+            base.append("\nReference Materials:")
+            base.append(dependencies_block)
+
+        if context:
+            base.append("\nPreviously created artifacts and context:")
+            base.append(self._format_context(context))
+
+        return "\n".join(base)
+
+    def get_prompt(self, task: str, context: Dict[str, Any]) -> str:  # type: ignore[override]
+        """Generate the user prompt passed to the OpenAI model."""
+
+        parts = [
+            f"Primary task: {task}",
+            "Follow the BMAD workflow guidance precisely and produce actionable output.",
+            "If required artifacts are missing, note the gap and propose next steps before proceeding.",
+            "\n" + self._format_commands(),
+        ]
+
+        if context:
+            parts.append("\nLeverage the available context when generating your response.")
+
+        return "\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # OpenAI execution
+    # ------------------------------------------------------------------
+    def _ensure_client(self, client: Optional["OpenAI"]) -> "OpenAI":
+        if client is not None:
+            return client
+
+        if self.client is not None:
+            return self.client
+
+        if OpenAI is None:  # pragma: no cover - requires optional dependency
+            raise ImportError(
+                "The 'openai' package is required to execute agents. Install it with 'pip install openai'."
+            )
+
+        # Allow the caller to override API key / organization via client_options
+        options = {**self._client_options}
+        api_key = options.pop("api_key", os.getenv("OPENAI_API_KEY"))
+        if api_key:
+            options.setdefault("api_key", api_key)
+
+        self.client = OpenAI(**options)
+        return self.client
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Best-effort extraction of textual content from a Responses API payload."""
+
+        # Newer SDK versions expose a convenience accessor.
+        text = getattr(response, "output_text", None)
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+
+        output = getattr(response, "output", None)
+        if output:
+            chunks: List[str] = []
+            for item in output:
+                content = getattr(item, "content", None)
+                if content is None and isinstance(item, dict):
+                    content = item.get("content")
+                if not content:
+                    continue
+                for block in content:
+                    text_obj = getattr(block, "text", None)
+                    if text_obj is None and isinstance(block, dict):
+                        text_obj = block.get("text")
+                    if text_obj is None:
+                        continue
+                    value = getattr(text_obj, "value", None)
+                    if value is None and isinstance(text_obj, dict):
+                        value = text_obj.get("value")
+                    if isinstance(value, str):
+                        chunks.append(value)
+            if chunks:
+                return "\n".join(chunks).strip()
+
+        # Fall back to string representation so the caller gets something useful.
+        return str(response)
+
+    def run(
+        self,
+        task: str,
+        context: Optional[Dict[str, Any]] = None,
+        *,
+        model: Optional[str] = None,
+        client: Optional["OpenAI"] = None,
+        response_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Execute the agent through the OpenAI Responses API."""
+
+        context = context or {}
+        active_client = self._ensure_client(client)
+
+        payload_kwargs = {**self.response_kwargs}
+        if response_kwargs:
+            payload_kwargs.update(response_kwargs)
+
+        response = active_client.responses.create(
+            model=model or self.model,
+            input=[
+                {"role": "system", "content": self.build_system_prompt(context)},
+                {"role": "user", "content": self.get_prompt(task, context)},
+            ],
+            **payload_kwargs,
+        )
+        return self._extract_text(response)

--- a/bmad_openai_sdk/prompts.py
+++ b/bmad_openai_sdk/prompts.py
@@ -1,0 +1,47 @@
+"""Prompt generation helpers for the OpenAI-powered SDK."""
+
+from __future__ import annotations
+
+import yaml
+from typing import Any, Dict
+
+
+def generate_prompt_from_template(template_path: str, context: Dict[str, Any]) -> str:
+    """Build a prompt string from a BMAD template file."""
+
+    try:
+        with open(template_path, "r", encoding="utf-8") as handle:
+            template = yaml.safe_load(handle)
+    except (FileNotFoundError, yaml.YAMLError) as exc:  # pragma: no cover - simple pass through
+        raise ValueError(f"Could not load or parse template from {template_path}: {exc}") from exc
+
+    prompt_parts = []
+    template_metadata = template.get("template", {})
+
+    prompt_parts.append(f"Subject: {template_metadata.get('name', 'Untitled Document')}")
+    prompt_parts.append(f"Version: {template_metadata.get('version', '1.0')}")
+    prompt_parts.append("\nInstructions:")
+
+    for section in template.get("sections", []):
+        title = section.get("title", "Unnamed Section")
+        instruction = section.get("instruction", "")
+
+        for key, value in context.items():
+            title = title.replace(f"{{{{{key}}}}}", str(value))
+            instruction = instruction.replace(f"{{{{{key}}}}}", str(value))
+
+        prompt_parts.append(f"\n## {title}")
+        if instruction:
+            prompt_parts.append(instruction)
+
+        examples = section.get("examples")
+        if examples:
+            prompt_parts.append("\nExamples:")
+            if isinstance(examples, list):
+                for example in examples:
+                    prompt_parts.append(f"- {example}")
+            elif isinstance(examples, dict):
+                for example_key, example_value in examples.items():
+                    prompt_parts.append(f"- {example_key}: {example_value}")
+
+    return "\n".join(prompt_parts)

--- a/bmad_openai_sdk/workflow.py
+++ b/bmad_openai_sdk/workflow.py
@@ -1,0 +1,209 @@
+"""Workflow orchestration backed by the OpenAI Agents SDK."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from .agents import OpenAIAgent
+
+
+@dataclass
+class WorkflowRunResult:
+    """Structured result returned from :meth:`OpenAIWorkflow.run`."""
+
+    log: List[str]
+    context: Dict[str, Any]
+
+
+class OpenAIWorkflow:
+    """Execute BMAD workflows using OpenAI-powered agents."""
+
+    def __init__(
+        self,
+        workflow_definition_path: str,
+        agent_definitions_base_path: str = "bmad-core/agents",
+        *,
+        client: Optional[Any] = None,
+        default_model: str = "gpt-4.1-mini",
+        agent_factory_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.workflow_definition_path = workflow_definition_path
+        self.agent_definitions_base_path = agent_definitions_base_path
+        self.sequence: List[Dict[str, Any]] = []
+        self.client = client
+        self.default_model = default_model
+        self.agent_factory_kwargs = agent_factory_kwargs or {}
+
+        self._load_workflow_definition()
+
+    # ------------------------------------------------------------------
+    # Loading helpers
+    # ------------------------------------------------------------------
+    def _load_workflow_definition(self) -> None:
+        with open(self.workflow_definition_path, "r", encoding="utf-8") as handle:
+            try:
+                definition = yaml.safe_load(handle)
+            except yaml.YAMLError as exc:  # pragma: no cover - simple pass through
+                raise ValueError(
+                    f"Could not parse YAML definition from {self.workflow_definition_path}: {exc}"
+                ) from exc
+
+        self.sequence = definition.get("workflow", {}).get("sequence", [])
+
+    # ------------------------------------------------------------------
+    # Execution helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _artifact_key(step: Dict[str, Any]) -> Optional[str]:
+        for key in ("creates", "updates", "action", "step"):
+            value = step.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        return None
+
+    @staticmethod
+    def _describe_step(step: Dict[str, Any]) -> str:
+        if "creates" in step:
+            return f"create {step['creates']}"
+        if "updates" in step:
+            return f"update {step['updates']}"
+        if "action" in step:
+            return step["action"]
+        return step.get("step", "Unnamed step")
+
+    @staticmethod
+    def _build_task_description(step: Dict[str, Any]) -> str:
+        parts: List[str] = []
+        if step.get("creates"):
+            parts.append(f"Create the artifact named '{step['creates']}'.")
+        if step.get("updates"):
+            parts.append(f"Update the artifact named '{step['updates']}'.")
+        if step.get("requires"):
+            required = step["requires"]
+            if isinstance(required, list):
+                required_str = ", ".join(required)
+            else:
+                required_str = str(required)
+            parts.append(f"Required context: {required_str}.")
+        if step.get("notes"):
+            parts.append(step["notes"])
+        if step.get("optional_steps"):
+            optional = ", ".join(step["optional_steps"])
+            parts.append(f"Optional subtasks to consider: {optional}.")
+        if step.get("condition"):
+            parts.append(f"Execute only if condition '{step['condition']}' is satisfied.")
+        return " ".join(parts) if parts else "Follow the BMAD workflow guidance for this step."
+
+    @staticmethod
+    def _should_skip(step: Dict[str, Any], context: Dict[str, Any]) -> bool:
+        condition = step.get("condition")
+        if not condition:
+            return False
+        return not bool(context.get(condition))
+
+    def _instantiate_agent(
+        self,
+        agent_id: str,
+        *,
+        overrides: Optional[Dict[str, Any]] = None,
+    ) -> OpenAIAgent:
+        definition_path = f"{self.agent_definitions_base_path}/{agent_id}.md"
+        combined_kwargs = {**self.agent_factory_kwargs}
+        overrides = overrides or {}
+        init_overrides = overrides.get("init", {})
+        combined_kwargs.update(init_overrides)
+
+        if "client" not in combined_kwargs:
+            combined_kwargs["client"] = self.client
+        if "model" not in combined_kwargs:
+            combined_kwargs["model"] = overrides.get("model", self.default_model)
+
+        return OpenAIAgent(agent_id, definition_path, **combined_kwargs)
+
+    def run(
+        self,
+        initial_context: Optional[Dict[str, Any]] = None,
+        *,
+        agent_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
+        dry_run: bool = False,
+    ) -> WorkflowRunResult:
+        """Execute the workflow and optionally call out to OpenAI."""
+
+        if not self.sequence:
+            return WorkflowRunResult(log=["Workflow sequence is not defined."], context=initial_context or {})
+
+        execution_log: List[str] = []
+        current_context = dict(initial_context or {})
+        agent_overrides = agent_overrides or {}
+
+        for raw_step in self.sequence:
+            if self._should_skip(raw_step, current_context):
+                execution_log.append(
+                    f"Skipping step '{self._describe_step(raw_step)}' because condition "
+                    f"'{raw_step.get('condition')}' is not satisfied."
+                )
+                continue
+
+            agent_spec = raw_step.get("agent")
+            if not agent_spec or agent_spec == "various":
+                notes_value = raw_step.get("notes", "")
+                notes_text = notes_value.strip() if isinstance(notes_value, str) else ""
+                execution_log.append(
+                    f"Non-agent step '{self._describe_step(raw_step)}': {notes_text}"
+                )
+                continue
+
+            actual_agent_id = agent_spec.split("/")[0].strip()
+            if actual_agent_id != agent_spec:
+                execution_log.append(
+                    f"Complex agent specifier '{agent_spec}' resolved to '{actual_agent_id}' for execution."
+                )
+
+            overrides = agent_overrides.get(actual_agent_id)
+            try:
+                agent = self._instantiate_agent(actual_agent_id, overrides=overrides)
+            except FileNotFoundError:
+                execution_log.append(
+                    f"Could not find agent definition for '{actual_agent_id}' in {self.agent_definitions_base_path}."
+                )
+                continue
+
+            task_description = self._build_task_description(raw_step)
+            log_prefix = agent.agent_info.get("title", actual_agent_id)
+
+            if dry_run:
+                execution_log.append(
+                    f"[Dry Run] {log_prefix} would {self._describe_step(raw_step)}. Task detail: {task_description}"
+                )
+                continue
+
+            run_kwargs = {}
+            if overrides:
+                run_kwargs = {**overrides.get("run", {})}
+                if "model" in overrides and "model" not in run_kwargs:
+                    run_kwargs["model"] = overrides["model"]
+
+            try:
+                result_text = agent.run(task_description, current_context, **run_kwargs)
+            except Exception as exc:  # pragma: no cover - defensive catch
+                execution_log.append(f"Agent '{actual_agent_id}' failed: {exc}")
+                continue
+
+            artifact_key = self._artifact_key(raw_step)
+            if artifact_key:
+                current_context[artifact_key] = result_text
+
+            if artifact_key:
+                execution_log.append(
+                    f"{log_prefix} completed step '{self._describe_step(raw_step)}' and produced artifact '{artifact_key}'."
+                )
+            else:
+                execution_log.append(
+                    f"{log_prefix} completed step '{self._describe_step(raw_step)}'."
+                )
+
+        execution_log.append("Workflow finished.")
+        return WorkflowRunResult(log=execution_log, context=current_context)

--- a/example_openai.py
+++ b/example_openai.py
@@ -1,0 +1,40 @@
+"""Example usage of the OpenAI-backed BMAD Python SDK."""
+
+from bmad_openai_sdk import OpenAIWorkflow, generate_prompt_from_template
+
+
+def run_workflow_example() -> None:
+    print("Starting BMAD OpenAI SDK Example...")
+
+    workflow_path = "bmad-core/workflows/greenfield-fullstack.yaml"
+    workflow = OpenAIWorkflow(workflow_definition_path=workflow_path)
+
+    # Dry run keeps the example runnable without an API key; set dry_run=False to call OpenAI.
+    result = workflow.run(
+        initial_context={"project_name": "Example App"},
+        dry_run=True,
+    )
+
+    print("\n--- Workflow Log ---")
+    for line in result.log:
+        print(line)
+
+
+def generate_prompt_example() -> None:
+    print("\n--- Generating Prompt ---")
+    template_path = "bmad-core/templates/prd-tmpl.yaml"
+    prompt = generate_prompt_from_template(
+        template_path,
+        {
+            "project_name": "Example App",
+            "user_type": "Administrator",
+            "action": "manage user access",
+            "benefit": "maintain security effortlessly",
+        },
+    )
+    print(prompt)
+
+
+if __name__ == "__main__":
+    run_workflow_example()
+    generate_prompt_example()


### PR DESCRIPTION
## Summary
- add a new `bmad_openai_sdk` package that wraps BMAD agents and workflows around the OpenAI Agents/Responses API
- document the OpenAI-specific SDK and cross-link it from the main README alongside the existing simulator
- provide an executable example that demonstrates running a workflow (dry run by default) and prompt generation with the new SDK

## Testing
- python -m compileall bmad_openai_sdk example_openai.py
- python example_openai.py

------
https://chatgpt.com/codex/tasks/task_e_68e1c2a00858832796161f4d68857f8e